### PR TITLE
Viewer: support archived channels

### DIFF
--- a/src/viewer/assets/styles.css
+++ b/src/viewer/assets/styles.css
@@ -31,6 +31,17 @@ nav, h1 {
   overflow: auto;
 }
 
+.channel-list li {
+  margin: 4px 0;
+}
+
+.tag {
+  padding: 0px 8px;
+  border-radius: 16px;
+  background-color:rgb(160, 160, 160);
+  color: white;
+}
+
 .debug-info {
   position: absolute;
   right: 8px;
@@ -76,7 +87,7 @@ nav, h1 {
 
 .message-anchor {
   position: absolute;
-  top: -100px;
+  top: -110px;
   width: 1px;
   height: 1px;
 }

--- a/src/viewer/helpers.js
+++ b/src/viewer/helpers.js
@@ -39,9 +39,9 @@ exports.getChannelName = function(type, channel) {
     case "public_channel":
     case "private_channel":
       return `#${channel.name}`;
-    case "direct_message":
+    case "im":
       return this.getUsernameById(channel.user);
-    case "multi_direct_message":
+    case "mpim":
       return channel?.purpose?.value ?? channel.name;
     default:
       return "Unknown";

--- a/src/viewer/views/channel-list.ejs
+++ b/src/viewer/views/channel-list.ejs
@@ -1,17 +1,20 @@
 <%- include('partials/header') %>
 
 <main>
-  <ol>
+  <ol class="channel-list">
     <% data[type].forEach(function(item) { %>
     <li>
+      <% if (item.is_archived) { %>
+        <span class="tag">archived</span>
+      <% } %>
       <a href="/list/<%= type %>/channel/<%= item.id %>">
-        <% if (type === 'direct_message') { %>
+        <% if (type === 'im') { %>
           <%- include('partials/user-card', {id: item.user}) %>
         <% } else { %>
           <%= getChannelName(type, item) %>
         <% } %>
       </a>
-      <% if (type === 'multi_direct_message' && item.purpose.creator) { %>
+      <% if (type === 'mpim' && item.purpose.creator) { %>
         <span class="message-tip">Created by <%- include('partials/user-card', {id: item.purpose.creator}) %></span>
       <% } %>
       <span class="message-timestamp" title="last updated"><%= formatDate(item.updated) %></span>

--- a/src/viewer/views/partials/message.ejs
+++ b/src/viewer/views/partials/message.ejs
@@ -1,4 +1,5 @@
 <% const msgId = `msg-${message.ts}` %>
+<% const assetUrl = `/${getAssetRootUrl(type)}/${archived}/messages/${channelId}/${message.ts}` %>
 <div class="message" data-index="<%= index %>" data-ts="<%= message.ts %>">
   <a class="message-anchor" name="<%= msgId %>"></a>
   <div class="message-header">
@@ -7,7 +8,7 @@
       ><%= formatDate(parseFloat(group.name)* 1000) %></span
     >
     <a href="#<%= msgId %>" class="message-link">#</a>
-    <a href="<%= `/json_data/${type}/unarchive/messages/${channelId}/${message.ts}/${message.ts}.json` %>" target="_blank" class="message-link">{}</a>
+    <a href="<%= `${assetUrl}/${message.ts}.json` %>" target="_blank" class="message-link">{}</a>
   </div>
   <pre class="message-body"><%- formatMessage(message.text) %></pre>
   <% if (message.files?.length) { %>
@@ -16,7 +17,7 @@
     <ul>
     <% message.files.forEach(function(file, index) { %>
       <li>
-        <a href="<%= `/json_data/${type}/unarchive/messages/${channelId}/${message.ts}/files/${message.ts}_${index}.${getExtName(file?.url_private)}` %>" target="_blank">
+        <a href="<%= `${assetUrl}/files/${message.ts}_${index}.${getExtName(file?.url_private)}` %>" target="_blank">
           <%= file.name %>
         </a>
       </li>


### PR DESCRIPTION
## New Features

* [x] Support viewing archived channels and messages

## Other changes:

* Use constants directly from `src/contants.js`, fix data source path:
  * from `json_data/private_channel` to `json_data/channels/private_channels`
  * from `json_data/public_channel` to `json_data/channels/public_channels`
* Fix hash link offset, click `#` to get the reference link of the message.
* Click `{}` to get the original JSON data file of the message.

If you are using remote workspace and download the zip files, please extract your zip archive to the correct path mentioned above!

Please check #1 for the usage.
